### PR TITLE
Added logic to show contact-us button

### DIFF
--- a/block_teaching_team.php
+++ b/block_teaching_team.php
@@ -76,7 +76,7 @@ class block_teaching_team extends block_base {
      * Generate block content
      */
     public function get_content() {
-        global $OUTPUT, $PAGE, $CFG;
+        global $OUTPUT, $PAGE, $CFG, $USER, $DB;
 
         require_once($CFG->libdir . '/filelib.php');
 
@@ -123,6 +123,26 @@ class block_teaching_team extends block_base {
             $this->content->text .= html_writer::tag('p', get_string('not_configured', 'block_teaching_team'));
         }
 
+        $courseid = $PAGE->course->id;
+        $context = context_course::instance($courseid);
+        $userroles = get_user_roles($context, $USER->id);
+        $mappings = $DB->get_records_menu('gs_contactus_config', null, '', 'id, fromroleid');
+
+        foreach ($userroles as $userrole) {
+            if (in_array($userrole->roleid, $mappings)) {
+                $this->content->text .= html_writer::start_tag('div');
+                $this->content->text .= html_writer::tag(
+                    'a',
+                    get_string('contact_us_form_support_page_link', 'block_teaching_team'),
+                    [
+                        'href' => '/blocks/teaching_team/contact_us.php',
+                        'class' => 'btn btn-primary mx-auto'
+                    ]
+                );
+                $this->content->text .= html_writer::end_tag('div');
+            }
+        }
+
         $this->content->text .= html_writer::end_tag('div');
 
         return $this->content;
@@ -144,7 +164,7 @@ class block_teaching_team extends block_base {
                 if (isset($this->config->grouping)) {
                     foreach ($this->get_user_groups($this->config->grouping, $courseid, $USER->id) as $groupid) {
                         $groupids.= $groupid->id.',';
-                    }                    
+                    }
                 }
 
                 if ($groupids === '') {
@@ -334,21 +354,21 @@ class block_teaching_team extends block_base {
     protected function get_user_groups($groupingname, $courseid, $userid) {
         global $DB;
 
-        $groupidsql = 'SELECT 
+        $groupidsql = 'SELECT
                            g.id
                         FROM
                             {groups_members} gm
                                 LEFT JOIN
                             {groups} g ON gm.groupid = g.id
                                 LEFT JOIN
-                            {groupings_groups} gg on g.id = gg.groupid               
-                                LEFT JOIN 
-                            {groupings} gs on gg.groupingid = gs.id    
+                            {groupings_groups} gg on g.id = gg.groupid
+                                LEFT JOIN
+                            {groupings} gs on gg.groupingid = gs.id
                         WHERE
                              gs.name = ? AND g.courseid = ? AND gm.userid = ?';
 
         $groupids = $DB->get_records_sql($groupidsql, array($groupingname, $courseid, $userid));
-        
+
         return $groupids;
 
     }

--- a/classes/output/form_role_types.php
+++ b/classes/output/form_role_types.php
@@ -49,7 +49,7 @@ class form_role_types implements \renderable, \templatable {
     public function get_data() {
         global $DB;
         $sql = '
-            SELECT gscc.id , gscc.salesforceapi AS salesforceapi, r.name AS name
+            SELECT gscc.id , gscc.salesforceapi AS salesforceapi, IF(r.name <> \'\', r.name, r.shortname) AS name
             FROM {gs_contactus_config} AS gscc
             INNER JOIN {user} AS u ON u.id = gscc.userid
             INNER JOIN {role} AS r ON r.id = gscc.fromroleid;

--- a/lang/en/block_teaching_team.php
+++ b/lang/en/block_teaching_team.php
@@ -73,3 +73,4 @@ $string['contact_us_form_page_heading'] = 'Contact Us Form';
 $string['contact_us_form_page_title'] = 'Contact Us Form';
 $string['contact_us_form_page_add_form_for_role_type'] = 'Create new form for role type';
 $string['contact_us_form_page_add_new_dropdown_value'] = 'Add new dropdown vale';
+$string['contact_us_form_support_page_link'] = 'Contact Us';


### PR DESCRIPTION
With role configured (styling could definitely be improved as the user information isn't centred properly)
<img width="1216" alt="Screenshot 2020-11-17 at 08 02 51" src="https://user-images.githubusercontent.com/72569635/99352495-6ab99d00-28ab-11eb-9ace-c7efa6ecca06.png">
Without role configured
<img width="1167" alt="Screenshot 2020-11-17 at 08 03 13" src="https://user-images.githubusercontent.com/72569635/99352550-80c75d80-28ab-11eb-97bc-43e75a100c50.png">

Also had to add IF to the SQL statement as if there is no role name (as the case with student) nothing would display in the table)